### PR TITLE
2: shortcuts firing in input mode

### DIFF
--- a/models/settings.go
+++ b/models/settings.go
@@ -67,7 +67,9 @@ func (m SettingsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "esc":
+		case "esc":
+			return ChangeView(m, ChannelInputState)
+		case "ctrl+c":
 			return m, tea.Quit
 		}
 	}


### PR DESCRIPTION
- Fixed single key inputs firing when the channel text input was active
- Changed escape on settings screen to return to channel input instead of closing the app