### PR TITLE
5 app creates duplicate chattermdb and debuglog files

### DIFF
--- a/db/connection.go
+++ b/db/connection.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"sync"
 )
@@ -12,9 +13,11 @@ var (
 	err        error
 )
 
-func OpenDB() *sql.DB {
+func OpenDB(path ...string) *sql.DB {
 	once.Do(func() {
-		dbInstance, err = sql.Open("sqlite3", "file:chatterm.db?cache=shared&mode=rwc")
+		// HACK: This should only be run by the call in main.go, so we're using an array to make it optional
+		// TODO: Find a better way to do this
+		dbInstance, err = sql.Open("sqlite3", fmt.Sprintf("file:%s/chatterm.db?cache=shared&mode=rwc", path[0]))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 		log.Fatalf("err: %w", err)
 	}
 	defer f.Close()
-	sql := db.OpenDB()
+	sql := db.OpenDB(configPath)
 	defer sql.Close()
 	db.CreateTables(sql)
 

--- a/main.go
+++ b/main.go
@@ -9,10 +9,12 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/zigzter/chatterm/db"
 	"github.com/zigzter/chatterm/models"
+	"github.com/zigzter/chatterm/utils"
 )
 
 func main() {
-	f, err := tea.LogToFile("debug.log", "debug")
+	configPath := utils.SetupPath()
+	f, err := tea.LogToFile(configPath+"/debug.log", "debug")
 	if err != nil {
 		log.Fatalf("err: %w", err)
 	}

--- a/utils/config.go
+++ b/utils/config.go
@@ -26,7 +26,7 @@ func createConfigDir(path string) error {
 	return nil
 }
 
-func setupPath() string {
+func SetupPath() string {
 	scope := gap.NewScope(gap.User, "chatterm")
 	dirs, err := scope.ConfigDirs()
 	if err != nil {
@@ -46,7 +46,7 @@ func setupPath() string {
 
 // InitConfig sets up the config, creating if necessary.
 func InitConfig() {
-	configPath := setupPath()
+	configPath := SetupPath()
 	viper.SetConfigName("config")
 	viper.SetConfigType("json")
 	viper.AddConfigPath(configPath)


### PR DESCRIPTION
- Debug file now uses the SetupPath function to store the debug file in the config file
- Trying to run SetupPath in the DB module causes an import cycle, so I made a hacky workaround, giving `OpenDB` an array of strings as an arg to make it optional. Since it's a singleton that gets created in `main.go`, this should be fine.

Both these changes should allow the program to be run from anywhere, without creating debug and database files where it was called from.