### PR TITLE
Switch to WebSocketSecure, add error UI, add HTTP error handling

### DIFF
--- a/twitch/commands.go
+++ b/twitch/commands.go
@@ -42,12 +42,20 @@ func httpClient() *http.Client {
 func fireRequest(req *http.Request) ([]byte, error) {
 	client := httpClient()
 	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	if resp == nil {
+		return nil, errors.New("HTTP request returned nil response")
+	}
+	defer resp.Body.Close()
+
 	var buff bytes.Buffer
 	_, err = io.Copy(&buff, resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-	defer resp.Body.Close()
+
 	statusOK := resp.StatusCode >= 200 && resp.StatusCode < 300
 	if !statusOK {
 		return nil, errors.New(string(buff.Bytes()))

--- a/utils/wsconnect.go
+++ b/utils/wsconnect.go
@@ -29,7 +29,7 @@ type WebSocketClient struct {
 
 // NewWebSocketClient creates and returns the websocket client
 func NewWebSocketClient() (*WebSocketClient, error) {
-	socketUrl := "ws://irc-ws.chat.twitch.tv:80"
+	socketUrl := "wss://irc-ws.chat.twitch.tv:443"
 	conn, _, err := websocket.DefaultDialer.Dial(socketUrl, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #11

This resolves the silent crash when selecting a channel by switching from `ws://` to `wss://` and adding error handling to http requests for slash commands which is another possible source of silent crashes I noticed.

## Changes

**1. Switch from WS to WSS**
- Changed from `ws://irc-ws.chat.twitch.tv:80` to `wss://irc-ws.chat.twitch.tv:443`
- The ws:// connection was causing "websocket: bad handshake" errors, Twitch seems to want TLS

**2. Add error handling to HTTP requests**
- Added nil checks in `fireRequest()` for slash commands like /ban, /info, etc.

**3. Add error UI for WebSocket connection failures**
- Added `connectionError` field to ChatModel to track connection state
- Displays an error message with troubleshooting guidance
- Shows debug log location for additional details
- Press Esc to return to channel selection instead of the app exiting

## Testing

macOS Tahoe v26.0.1

Built and tested with `ws://` and confirmed error ui displays and functions correctly.
Built and tested with `wss://` and confirmed bad handshake is resolved